### PR TITLE
fix: restore AdminPanel
      lint/format config after repo split

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,6 +4,9 @@ build
 coverage
 .next
 out
+AdminPanel/client/src/pages/AiIntegration/ai/**
+AdminPanel/client/src/pages/AiIntegration/js/plugins.js
+AdminPanel/client/src/pages/AiIntegration/js/plugins-ui.js
 *.min.js
 *.min.css
 package-lock.json

--- a/AdminPanel/client/src/App.css
+++ b/AdminPanel/client/src/App.css
@@ -76,7 +76,7 @@ body::-webkit-scrollbar-thumb {
 }
 
 a {
-  color: #0082C9;
+  color: #0082c9;
   text-decoration: underline;
   font-weight: 400;
 }

--- a/AdminPanel/client/src/components/AccessRules/AccessRules.module.scss
+++ b/AdminPanel/client/src/components/AccessRules/AccessRules.module.scss
@@ -34,7 +34,7 @@
 }
 
 .addButton {
-  background: #0082C9;
+  background: #0082c9;
   color: #ffffff;
   border: none;
   height: 48px;

--- a/AdminPanel/client/src/components/Button/Button.module.scss
+++ b/AdminPanel/client/src/components/Button/Button.module.scss
@@ -1,5 +1,5 @@
 .button {
-  background: #0082C9;
+  background: #0082c9;
   width: 154px;
   height: 48px;
   padding: 13px 24px;
@@ -25,7 +25,7 @@
   }
 
   &--loading {
-    background: #0082C9;
+    background: #0082c9;
     cursor: wait;
   }
 

--- a/AdminPanel/client/src/components/Checkbox/Checkbox.module.scss
+++ b/AdminPanel/client/src/components/Checkbox/Checkbox.module.scss
@@ -43,8 +43,8 @@
 }
 
 .checkbox:checked ~ .checkmark {
-  background: #0082C9;
-  border-color: #0082C9;
+  background: #0082c9;
+  border-color: #0082c9;
 
   &::after {
     display: block;

--- a/AdminPanel/client/src/components/Note/Note.module.scss
+++ b/AdminPanel/client/src/components/Note/Note.module.scss
@@ -65,10 +65,10 @@
 
 /* Note variant - Orange */
 .note {
-  border-left: 2px solid #0082C9;
+  border-left: 2px solid #0082c9;
 
   .title {
-    color: #0082C9;
+    color: #0082c9;
   }
 }
 

--- a/AdminPanel/client/src/components/Select/Select.module.scss
+++ b/AdminPanel/client/src/components/Select/Select.module.scss
@@ -96,7 +96,7 @@
   }
 
   &--selected {
-    color: #0082C9;
+    color: #0082c9;
     font-weight: 600;
   }
 }

--- a/AdminPanel/client/src/components/Tabs/Tabs.module.scss
+++ b/AdminPanel/client/src/components/Tabs/Tabs.module.scss
@@ -39,12 +39,12 @@
   }
 
   &--active {
-    color: #0082C9;
+    color: #0082c9;
 
     &:hover,
     &:focus,
     &:active {
-      color: #0082C9; /* ensure orange while focused/pressed */
+      color: #0082c9; /* ensure orange while focused/pressed */
     }
 
     &::after {
@@ -54,7 +54,7 @@
       left: 0;
       right: 0;
       height: 2px;
-      background: #0082C9;
+      background: #0082c9;
     }
   }
 }

--- a/AdminPanel/client/webpack.config.js
+++ b/AdminPanel/client/webpack.config.js
@@ -4,9 +4,7 @@ const CopyPlugin = require('copy-webpack-plugin');
 const webpack = require('webpack');
 const dotenv = require('dotenv');
 
-const outputDir = process.env.BUILD_ROOT
-                  ? path.resolve(process.env.BUILD_ROOT, 'build')
-                  : path.resolve(__dirname, 'build');
+const outputDir = process.env.BUILD_ROOT ? path.resolve(process.env.BUILD_ROOT, 'build') : path.resolve(__dirname, 'build');
 
 const appName = process.env.APP_NAME || 'Euro-Office';
 
@@ -56,8 +54,8 @@ module.exports = (env, argv) => {
       new HtmlWebpackPlugin({
         template: path.join(__dirname, 'public', 'index.html'),
         templateParameters: {
-          appName,
-        },
+          appName
+        }
       }),
       new CopyPlugin({
         patterns: [
@@ -96,8 +94,8 @@ module.exports = (env, argv) => {
       }),
       new webpack.DefinePlugin({
         'process.env.REACT_APP_BACKEND_URL': JSON.stringify(process.env.REACT_APP_BACKEND_URL),
-        'process.env.APP_NAME': JSON.stringify(appName),
-      }),
+        'process.env.APP_NAME': JSON.stringify(appName)
+      })
     ],
 
     module: {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,6 +3,9 @@ const globals = require('globals');
 const prettier = require('eslint-config-prettier');
 const {includeIgnoreFile} = require('@eslint/compat');
 const path = require('node:path');
+const react = require('eslint-plugin-react');
+const reactHooks = require('eslint-plugin-react-hooks');
+
 const gitignorePath = path.resolve(__dirname, '.gitignore');
 
 module.exports = [
@@ -15,6 +18,9 @@ module.exports = [
       'coverage/',
       '.next/',
       'out/',
+      'AdminPanel/client/src/pages/AiIntegration/ai/**',
+      'AdminPanel/client/src/pages/AiIntegration/js/plugins.js',
+      'AdminPanel/client/src/pages/AiIntegration/js/plugins-ui.js',
       '*.min.js',
       'package-lock.json',
       'npm-shrinkwrap.json',
@@ -60,6 +66,23 @@ module.exports = [
       'no-useless-constructor': 'error', // Remove unnecessary constructors
       'no-useless-return': 'error', // Remove unnecessary return statements
       'max-lines': ['warn', 5000]
+    }
+  },
+  {
+    files: ['AdminPanel/client/**/*.{js,jsx}'],
+    plugins: {react, 'react-hooks': reactHooks},
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: 'module',
+      parserOptions: {ecmaFeatures: {jsx: true}},
+      globals: {...globals.browser, ...globals.es2022}
+    },
+    settings: {react: {version: 'detect'}},
+    rules: {
+      'react/react-in-jsx-scope': 'off',
+      'react/jsx-uses-vars': 'error',
+      'react-hooks/rules-of-hooks': 'error',
+      'react-hooks/exhaustive-deps': 'warn'
     }
   },
   prettier

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -388,7 +388,8 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@eslint/compat/-/compat-1.2.3.tgz",
       "integrity": "sha512-wlZhwlDFxkxIZ571aH0FoK4h4Vwx7P3HJx62Gp8hTc10bfpwT2x0nULuAHmQSJBOWPgPeVf+9YtnD4j50zVHmA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@eslint/config-array": {
       "version": "0.19.2",
@@ -1247,7 +1248,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ajv": {
       "version": "6.12.6",
@@ -2056,7 +2058,8 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.6.0.tgz",
       "integrity": "sha512-F1Z+5UCFpmQUzJa11agbyPVMbpgT/qA3/SKyJ1jyBgm7dUcUEa8v9JwDkerSQXfakBwFljIxhOJqGkjUwZ9FSA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "deep-extend": {
       "version": "0.6.0",
@@ -2523,7 +2526,8 @@
       "version": "10.1.8",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-plugin-react": {
       "version": "7.37.5",
@@ -2574,7 +2578,8 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.2.0.tgz",
       "integrity": "sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-scope": {
       "version": "8.4.0",
@@ -4218,7 +4223,8 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
       "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jest-regex-util": {
       "version": "29.6.3",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "cross-env": "7.0.3",
     "eslint": "9.16.0",
     "eslint-config-prettier": "10.1.8",
+    "eslint-plugin-react": "^7.37.2",
+    "eslint-plugin-react-hooks": "^5.2.0",
     "express": "4.21.2",
     "globals": "15.12.0",
     "husky": "8.0.3",


### PR DESCRIPTION
## Summary

`npm run lint:check` was failing on every JSX file in `AdminPanel/client` with parse errors. The upstream repo-split commit removed the React/JSX ESLint config and the AiIntegration prettier ignores on the assumption AdminPanel had moved out, but the directory still lives in this fork.

- Restore the JSX ESLint config block (parser + `eslint-plugin-react`/`-react-hooks`) and AiIntegration ignores; re-add the two plugin devDeps
- Re-ignore the vendored AiIntegration files in prettier (they broke `format:check`, including a no-parser error on `vocabulary.bpe`)
- Format the remaining first-party AdminPanel css/scss/webpack files

After this, `lint:check` and `format:check` both pass.
