### PR TITLE
ci: e2e job overlaying fresh server build on nightly image

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,126 @@
+name: E2E (overlay on nightly)
+
+# Builds the server binaries, overlays them onto the published
+# ghcr.io/euro-office/documentserver:nightly image, and runs the DocumentServer
+# Playwright e2e suite against it. Fast feedback on a server change against the
+# full stack without rebuilding core/sdkjs/web-apps.
+#
+# Scope: overlays the four pkg binaries (docservice, fileconverter, metrics,
+# adminpanel). The AdminPanel webpack client is intentionally NOT overlaid —
+# the e2e suite never exercises the admin UI, so the nightly image's client
+# build is left in place.
+on:
+  push:
+    branches:
+      - fork
+      - develop
+      - 'release/**'
+      - 'hotfix/**'
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  NIGHTLY_IMAGE: ghcr.io/euro-office/documentserver:nightly
+  OVERLAY_IMAGE: euro-office/documentserver:e2e-server
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check out server
+        uses: actions/checkout@v4
+        with:
+          path: server
+
+      # The e2e suite lives in the DocumentServer repo. Prefer a same-named
+      # branch (so tests can be co-developed with the change), else main.
+      - name: Check out DocumentServer e2e (current branch)
+        id: docserver
+        uses: actions/checkout@v4
+        continue-on-error: true
+        with:
+          repository: Euro-Office/DocumentServer
+          path: documentserver
+          ref: ${{ github.head_ref || github.ref_name }}
+      - name: Check out DocumentServer e2e (main)
+        if: steps.docserver.outcome != 'success'
+        uses: actions/checkout@v4
+        with:
+          repository: Euro-Office/DocumentServer
+          path: documentserver
+          ref: main
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      # Mirrors server.bake.Dockerfile: install each package, then pkg the four
+      # services into $BUILD_ROOT.
+      - name: Build server binaries
+        working-directory: server
+        env:
+          BUILD_ROOT: ${{ github.workspace }}/server/deploy
+        run: |
+          npm install -g @yao-pkg/pkg
+          for d in Common DocService FileConverter Metrics; do
+            ( cd "$d" && npm install )
+          done
+          mkdir -p "$BUILD_ROOT"
+          ( cd DocService    && pkg . -t linux-x64 --node-options="--max_old_space_size=4096" -o "$BUILD_ROOT/docservice" )
+          ( cd FileConverter && pkg . -t linux-x64 --node-options="--max_old_space_size=4096" -o "$BUILD_ROOT/fileconverter" )
+          ( cd Metrics       && pkg . -t linux-x64 --node-options="--max_old_space_size=4096" -o "$BUILD_ROOT/metrics" )
+
+      - name: Pull nightly image
+        run: docker pull ${{ env.NIGHTLY_IMAGE }}
+
+      - name: Build overlay image with fresh server binaries
+        run: |
+          set -euo pipefail
+          cat > overlay.Dockerfile <<'EOF'
+          ARG NIGHTLY_IMAGE
+          FROM ${NIGHTLY_IMAGE}
+          COPY docservice fileconverter metrics /tmp/srv/
+          # The install path is brand-derived (/var/www/<brand>/documentserver);
+          # locate it via the sdkjs dir, then replace the service binaries.
+          RUN set -eux; \
+              root="$(dirname "$(find /var/www -maxdepth 5 -type d -name sdkjs -path '*documentserver*' | head -n1)")"; \
+              test -n "$root"; \
+              install -m0755 /tmp/srv/docservice    "$root/server/DocService/docservice"; \
+              install -m0755 /tmp/srv/fileconverter "$root/server/FileConverter/converter"; \
+              install -m0755 /tmp/srv/metrics       "$root/server/Metrics/metrics"; \
+              rm -rf /tmp/srv
+          EOF
+          docker build \
+            --build-arg NIGHTLY_IMAGE=${{ env.NIGHTLY_IMAGE }} \
+            -t ${{ env.OVERLAY_IMAGE }} \
+            -f overlay.Dockerfile \
+            server/deploy
+
+      - name: Install e2e dependencies
+        working-directory: documentserver/e2e
+        run: npm ci
+
+      - name: Install Playwright browsers
+        working-directory: documentserver/e2e
+        run: npx playwright install chromium --with-deps
+
+      - name: Run E2E tests
+        working-directory: documentserver/e2e
+        env:
+          E2E_IMAGE: ${{ env.OVERLAY_IMAGE }}
+        run: npm test
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-${{ github.sha }}
+          path: documentserver/e2e/playwright-report/
+          retention-days: 14

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -61,14 +61,36 @@ jobs:
         with:
           node-version: 20
 
-      # Mirrors server.bake.Dockerfile: install each package, then pkg the four
-      # services into $BUILD_ROOT.
+      - name: Pull nightly image
+        run: docker pull ${{ env.NIGHTLY_IMAGE }}
+
+      # docservice rejects an editor whose version differs from its own
+      # (services gate on an exact buildVersion match). The bake injects
+      # PRODUCT_VERSION into commondefines.js; replicate that with the version
+      # the nightly image was built with so the fresh docservice matches the
+      # nightly editor. Read it from the image so it tracks version bumps.
+      - name: Read nightly product version
+        id: ver
+        run: |
+          set -euo pipefail
+          VER=$(docker run --rm --entrypoint sh ${{ env.NIGHTLY_IMAGE }} -c \
+            "grep -A2 'DocsAPI.DocEditor.version = function' \
+              \$(find /var/www -maxdepth 6 -path '*api/documents/api.js' | head -n1) \
+              | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1")
+          test -n "$VER"
+          echo "product_version=$VER" >> "$GITHUB_OUTPUT"
+          echo "nightly PRODUCT_VERSION=$VER"
+
+      # Mirrors server.bake.Dockerfile: stamp buildVersion, install each package,
+      # then pkg the services into $BUILD_ROOT.
       - name: Build server binaries
         working-directory: server
         env:
           BUILD_ROOT: ${{ github.workspace }}/server/deploy
+          PRODUCT_VERSION: ${{ steps.ver.outputs.product_version }}
         run: |
           npm install -g @yao-pkg/pkg
+          sed -i "s|\(const buildVersion = \).*|\1'${PRODUCT_VERSION}';|" Common/sources/commondefines.js
           for d in Common DocService FileConverter Metrics; do
             ( cd "$d" && npm install )
           done
@@ -76,9 +98,6 @@ jobs:
           ( cd DocService    && pkg . -t linux-x64 --node-options="--max_old_space_size=4096" -o "$BUILD_ROOT/docservice" )
           ( cd FileConverter && pkg . -t linux-x64 --node-options="--max_old_space_size=4096" -o "$BUILD_ROOT/fileconverter" )
           ( cd Metrics       && pkg . -t linux-x64 --node-options="--max_old_space_size=4096" -o "$BUILD_ROOT/metrics" )
-
-      - name: Pull nightly image
-        run: docker pull ${{ env.NIGHTLY_IMAGE }}
 
       - name: Build overlay image with fresh server binaries
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -75,7 +75,7 @@ jobs:
           set -euo pipefail
           VER=$(docker run --rm --entrypoint sh ${{ env.NIGHTLY_IMAGE }} -c \
             "grep -A2 'DocsAPI.DocEditor.version = function' \
-              \$(find /var/www -maxdepth 6 -path '*api/documents/api.js' | head -n1) \
+              \$(find /var/www -maxdepth 8 -path '*api/documents/api.js' | head -n1) \
               | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1")
           test -n "$VER"
           echo "product_version=$VER" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Adds an `e2e` workflow that builds the server binaries, overlays them onto `ghcr.io/euro-office/documentserver:nightly`, and runs the DocumentServer Playwright e2e suite against it. Full-stack feedback on a server change without rebuilding core/sdkjs/web-apps.

## How it works
- Pulls the nightly image and reads the `PRODUCT_VERSION` it was built with.
- Stamps that version into `commondefines.js` (mirroring the bake), then pkg-builds the service binaries (`docservice`, `fileconverter`, `metrics`).
- Replaces the matching binaries in the image (`server/DocService/docservice`, `server/FileConverter/converter`, `server/Metrics/metrics`); install path discovered via the `sdkjs` dir. Runs the e2e suite from `Euro-Office/DocumentServer` (matching branch, fallback `main`).

## Notes
- docservice rejects an editor whose `buildVersion` differs from its own, so the fresh docservice must carry the nightly image version — hence the `commondefines.js` stamp.
- The AdminPanel webpack client is intentionally not overlaid; the e2e suite never exercises the admin UI.
- All involved repos and the documentserver package are public (no PAT).

Verified green against the current nightly.