### PR TITLE
feat: add internalUrl option to avoid hairpin-NAT on self-fetches

### DIFF
--- a/Common/config/default.json
+++ b/Common/config/default.json
@@ -346,7 +346,8 @@
         "documentFormatsFile": "../../document-formats/onlyoffice-docs-formats.json",
         "downloadFileAllowExt": ["pdf", "xlsx"],
         "tokenRequiredParams": true,
-        "forceSaveUsingButtonWithoutChanges": false
+        "forceSaveUsingButtonWithoutChanges": false,
+        "internalUrl": ""
       },
       "requestDefaults": {
         "headers": {

--- a/Common/sources/utils.js
+++ b/Common/sources/utils.js
@@ -78,6 +78,7 @@ const cfgSecret = config.get('aesEncrypt.secret');
 const cfgAESConfig = config.util.cloneDeep(config.get('aesEncrypt.config'));
 const cfgRequesFilteringAgent = config.get('services.CoAuthoring.request-filtering-agent');
 const cfgStorageExternalHost = config.get('storage.externalHost');
+const cfgInternalUrl = config.get('services.CoAuthoring.server.internalUrl');
 const cfgExternalRequestDirectIfIn = config.get('externalRequest.directIfIn');
 const cfgExternalRequestAction = config.get('externalRequest.action');
 const cfgWinCa = config.util.cloneDeep(config.get('win-ca'));
@@ -346,8 +347,16 @@ async function downloadUrlPromise(ctx, uri, optTimeout, optLimit, opt_Authorizat
   const tenTenantRequestDefaults = ctx.getCfg('services.CoAuthoring.requestDefaults', cfgRequestDefaults);
   const tenTokenOutboxHeader = ctx.getCfg('services.CoAuthoring.token.outbox.header', cfgTokenOutboxHeader);
   const tenTokenOutboxPrefix = ctx.getCfg('services.CoAuthoring.token.outbox.prefix', cfgTokenOutboxPrefix);
+  const tenInternalUrl = ctx.getCfg('services.CoAuthoring.server.internalUrl', cfgInternalUrl);
+  const tenStorageExternalHost = ctx.getCfg('storage.externalHost', cfgStorageExternalHost);
   const sizeLimit = optLimit || Number.MAX_VALUE;
   uri = URI.serialize(URI.parse(uri));
+  if (tenInternalUrl && tenStorageExternalHost) {
+    const externalOrigin = tenStorageExternalHost.replace(/\/$/, '');
+    if (uri.startsWith(externalOrigin + '/') || uri === externalOrigin) {
+      uri = tenInternalUrl.replace(/\/$/, '') + uri.slice(externalOrigin.length);
+    }
+  }
   const options = config.util.cloneDeep(tenTenantRequestDefaults);
 
   //baseRequest creates new agent(win-ca injects in globalAgent)


### PR DESCRIPTION
## Problem

When DocService and its nginx reverse proxy are co-located on the same host, internally-generated signed file URLs use the public hostname (e.g. `https://eo.nextcloud.com/cache/...`). When DocService or FileConverter fetches one of these URLs itself (via the `/downloadfile` proxy endpoint or a converter source download), the request must traverse the router. Many routers do not apply inbound NAT rules to traffic originating from the inside, so the connection fails or the TLS handshake breaks -- the classic hairpin-NAT / split-horizon DNS problem.

## Solution

Adds `services.CoAuthoring.server.internalUrl` config key (default: `""`).

When both `services.CoAuthoring.server.internalUrl` and `storage.externalHost` are set, any URL passed to `downloadUrlPromise` whose origin matches `storage.externalHost` has its origin rewritten to `internalUrl` before the HTTP request is made. All URLs sent to browsers or included in Nextcloud callbacks are unaffected -- only the internal fetch path is rewritten.

## Configuration

Add to your environment config (e.g. `production-linux.json`):

```json
{
  "storage": {
    "externalHost": "https://eo.nextcloud.com"
  },
  "services": {
    "CoAuthoring": {
      "server": {
        "internalUrl": "http://localhost:8080"
      }
    }
  }
}
```

`storage.externalHost` is the public base URL already used to build signed storage URLs. `internalUrl` is the address DocService can reach itself on directly -- typically `http://localhost:<port>` where port matches `services.CoAuthoring.server.port`.

With both set, a fetch of `https://eo.nextcloud.com/cache/files/data/abc/output.docx?md5=...` becomes `http://localhost:8080/cache/files/data/abc/output.docx?md5=...`, staying entirely on-host with no TLS or NAT involved.

The rewrite is per-tenant aware and does not affect the `rejectUnauthorized` setting or any other request options.