### PR TITLE
feat: raise maxDownloadBytes and inputLimits to 500MB

### DIFF
--- a/Common/config/default.json
+++ b/Common/config/default.json
@@ -542,7 +542,7 @@
   },
   "FileConverter": {
     "converter": {
-      "maxDownloadBytes": 104857600,
+      "maxDownloadBytes": 524288000,
       "downloadTimeout": {
         "connectionAndInactivity": "2m",
         "wholeCycle": "2m"
@@ -594,28 +594,28 @@
         {
           "type": "docx;dotx;docm;dotm",
           "zip": {
-            "uncompressed": "50MB",
+            "uncompressed": "500MB",
             "template": "*.xml"
           }
         },
         {
           "type": "xlsx;xltx;xlsm;xltm",
           "zip": {
-            "uncompressed": "300MB",
+            "uncompressed": "500MB",
             "template": "*.xml"
           }
         },
         {
           "type": "pptx;ppsx;potx;pptm;ppsm;potm",
           "zip": {
-            "uncompressed": "50MB",
+            "uncompressed": "500MB",
             "template": "*.xml"
           }
         },
         {
           "type": "vsdx;vstx;vssx;vsdm;vstm;vssm",
           "zip": {
-            "uncompressed": "50MB",
+            "uncompressed": "500MB",
             "template": "*.xml"
           }
         }


### PR DESCRIPTION
## Context

Companion PR to Euro-Office/DocumentServer#210 (raises the default file-size limits and makes them runtime-configurable). **Both PRs must be merged together** — the DocumentServer PR bumps the `server` submodule pointer to the commit introduced here.

## What changes

`Common/config/default.json`:

- `FileConverter.converter.maxDownloadBytes`: 100 MB → 500 MB
- All four `inputLimits` uncompressed zip sizes (docx, xlsx, pptx, vsdx): 50 MB / 300 MB → 500 MB

These are the built-in defaults baked into the image. The DocumentServer entrypoints expose `FILECONVERTER_MAX_DOWNLOAD_BYTES` and `FILECONVERTER_INPUT_LIMIT_UNCOMPRESSED` env vars that override these values at runtime without needing to mount a config file.

Closes (companion): https://github.com/Euro-Office/DocumentServer/issues/210

Assisted-by: ClaudeCode:claude-sonnet-4-6